### PR TITLE
Convert validity_date from date to datetime

### DIFF
--- a/stake/asx/order.py
+++ b/stake/asx/order.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from typing import List, Optional, Union
 from uuid import UUID
 
@@ -29,7 +29,7 @@ class Order(BaseModel):
     side: Side
     type: TradeType
     units_remaining: Optional[int] = None
-    validity_date: Optional[datetime] = None
+    validity_date: Optional[Union[date,datetime]] = None
     validity: Optional[str] = None
 
     class Config:


### PR DESCRIPTION
This pull request just attempts to convert `validity_date` from YYYY-MM-DD format to a datetime object as pydantic does not appear to support converting a date string to a datetime object.

I'm not sure if this is the best way to do it, but it works in my case.

Exception I was getting:
```
  File "/usr/local/lib/python3.12/site-packages/stake/asx/order.py", line 58, in list
    return [Order(**d) for d in data]
            ^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 341, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for Order
validityDate
  invalid datetime format (type=value_error.datetime)
```

Order that was causing the error:
```
{
 'id': 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
 'broker': 'FINCLEAR',
 'brokerOrderId': 12345678,
 'brokerOrderVersionId': 4,
 'brokerInstructionId': 1234565789,
 'brokerInstructionVersionId': 2,
 'userId': 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
 'instrumentId': None,
 'instrumentCode': 'XXXX.XAU',
 'side': 'SELL',
 'limitPrice': 12.34,
 'triggerPrice': None,
 'trailingPercentage': None,
 'validity': 'GTD',
 'validityDate': '2024-01-03',
 'type': 'LIMIT',
 'placedTimestamp': '2023-12-04T10:39:25.982432',
 'completedTimestamp': None,
 'expiresAt': '2024-01-03T00:00:00',
 'orderStatus': 'OPEN',
 'orderCompletionType': None,
 'filledUnits': 0,
 'averagePrice': None,
 'unitsRemaining': 99,
 'unitsRequested': 99,
 'estimatedBrokerage': 3.0,
 'estimatedExchangeFees': 0.0,
 'cancellationEventSent': False,
 'brokerageDiscount': 0.0,
 'pendingBrokerage': 0.0,
 'chargedBrokerage': 0.0,
 'fcPlacementAttempts': None,
 'allowAwaitingTrigger': True,
 'cancellationReason': None,
 'cancellationDetail': None,
 'currentExecutionPrice': None,
 'anchorPrice': None,
 'stakeManaged': False
}
``` 